### PR TITLE
Add MTEscape (CCS 2026) publication

### DIFF
--- a/assets/pubs/conf.bib
+++ b/assets/pubs/conf.bib
@@ -36,6 +36,14 @@
   year        = 2026,
 }
 
+@Proceedings{CCS26,
+  title       = POT # { 33rd } # CCS,
+  booktitle   = POT # { 33rd } # CCS,
+  month       = nov,
+  year        = 2026,
+  address     = {The Hague, The Netherlands},
+}
+
 @Proceedings{NDSS26,
   title       = POT # { 2026 } # NDSS,
   booktitle   = POT # { 2026 } # NDSS,

--- a/assets/pubs/pub.bib
+++ b/assets/pubs/pub.bib
@@ -3,6 +3,12 @@
 %% award      : award
 
 %% 2026
+@InProceedings{kim:mtescape,
+  title         = {{MTEscape: Bypassing Asynchronous Kernel MTE via Conventional Memory Corruption Vulnerabilities (to appear)}},
+  author        = {Kyeongmin Kim and Insu Yun},
+  crossref      = {CCS26},
+}
+
 @InProceedings{choi:prism,
   title         = {{Prism: A Multi-Team Orchestration of LLM Agents for Automatic Program Repair (to appear)}},
   author        = {Yunjae Choi and Min Woo Baek and Insu Yun},
@@ -275,4 +281,3 @@
   crossref      = {CCS12},
   www-url       = "https://shader.kaist.edu/kargus/",
 }
-

--- a/content/home/news.md
+++ b/content/home/news.md
@@ -15,6 +15,7 @@ weight: 15
 title: News
 
 ---
+* [08/29/2026] MTEscape is accepted to [CCS '26](https://www.sigsac.org/ccs/CCS2026/index.html)!
 * [08/09/2026] Team 0x4b52 wins 2nd place at [DEF CON CTF 34 Finals](https://defcon.org/html/links/dc-ctf.html)!
 * [07/24/2026] Four members of our lab are named [Microsoft MSRC 2026 Most Valuable Researchers](https://ee.kaist.ac.kr/en/research-achieve/four-researchers-from-prof-insu-yuns-lab-named-microsoft-msrc-2026-most-valuable-researchers/)!
 * [07/10/2026] Prism is accepted to [RAID '26](https://raid2026.org/)!

--- a/content/publication/kim-mtescape/cite.bib
+++ b/content/publication/kim-mtescape/cite.bib
@@ -1,0 +1,8 @@
+@proceedings{kim:mtescape,
+ address = {The Hague, The Netherlands},
+ author = {Kyeongmin Kim and Insu Yun},
+ booktitle = {Proceedings of the 33rd ACM Conference on Computer and Communications Security (CCS)},
+ month = {November},
+ title = {{MTEscape: Bypassing Asynchronous Kernel MTE via Conventional Memory Corruption Vulnerabilities (to appear)}},
+ year = {2026}
+}

--- a/content/publication/kim-mtescape/index.md
+++ b/content/publication/kim-mtescape/index.md
@@ -1,0 +1,38 @@
+---
+# Documentation: https://wowchemy.com/docs/managing-content/
+
+title: 'MTEscape: Bypassing Asynchronous Kernel MTE via Conventional Memory Corruption
+  Vulnerabilities (to appear)'
+subtitle: ''
+summary: ''
+authors:
+- Kyeongmin Kim
+- Insu Yun
+tags: []
+categories: []
+date: '2026-11-01'
+lastmod: 2026-08-29T11:41:42+09:00
+featured: false
+draft: false
+
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+# Focal points: Smart, Center, TopLeft, Top, TopRight, Left, Right, BottomLeft, Bottom, BottomRight.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+
+# Projects (optional).
+#   Associate this post with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `projects = ["internal-project"]` references `content/project/deep-learning/index.md`.
+#   Otherwise, set `projects = []`.
+projects: []
+publishDate: '2026-08-29T02:41:42.293840Z'
+publication_types:
+- '0'
+abstract: ''
+publication: '*Proceedings of the 33rd ACM Conference on Computer and Communications
+  Security (CCS)*'
+---


### PR DESCRIPTION
## Summary

- add MTEscape as a CCS 2026 publication marked as to appear
- add the CCS 2026 venue metadata
- announce the acceptance in News

The paper body, abstract, and paper link are intentionally omitted until publication.

## Test

- Hugo 0.78.2 build